### PR TITLE
Add a (lazy) way to escape `<pre>` building

### DIFF
--- a/lib/options/md.js
+++ b/lib/options/md.js
@@ -17,13 +17,15 @@ mdConvert.setOptions({
 
 renderer.code = function (code, language) {
 	var codeExample = '';
-	var codeWrapped;
+	var codeWrapped = '';
 
 	if (language !== 'css' && language !== 'js')
 		codeExample = code + '\n';
 
 	code = hljs.highlightAuto(code).value;
-	codeWrapped = '<pre class="code">' + '<code class="' + (language ? language : "") + '">' + code + '</code>' + '</pre>';
+
+	if (language !== 'esc')
+		codeWrapped = '<pre class="code">' + '<code class="' + (language ? language : "") + '">' + code + '</code>' + '</pre>';
 
 	return codeExample + codeWrapped;
 };


### PR DESCRIPTION
At first, the idea was to list icons. Since the icon md file comes with the font files, we just need to return a `<pre><i class="icon icon-example"></i>` once and not for each icon.
Instead of doing something very specific for icons, I just added `esc` which stands for escape.